### PR TITLE
Beautify heatmap

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -9,9 +9,10 @@
 
 #heatmapSlider{
     // border: 1px solid black;
-    -webkit-box-shadow: 0px 13px 22px 0px rgba(50, 50, 50, 0.53);
-    -moz-box-shadow:    0px 13px 22px 0px rgba(50, 50, 50, 0.53);
-    box-shadow:         0px 13px 22px 0px rgba(50, 50, 50, 0.53);
+    // -webkit-box-shadow: 0px 13px 22px 0px rgba(50, 50, 50, 0.53);
+    // -moz-box-shadow:    0px 13px 22px 0px rgba(50, 50, 50, 0.53);
+    // box-shadow:         0px 13px 22px 0px rgba(50, 50, 50, 0.53);
+    background: #f9f7f7
 }
 #innerheatmapSVG{
     background: #f9f7f7

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -31,7 +31,7 @@
         <div id="heatmapLegend" ref="heatmapLegend"></div>
         <b-button @click="downloadSVG()">Save SVG</b-button>
         <a hidden id='imgId' target="_blank">Save SVG</a>
-        <b-switch v-model="isFlipped" hidden :disabled="!this.DataHandler.cells" >
+        <b-switch v-model="isFlipped" hidden :disabled="!DataHandler.cells" >
                 {{ ( isFlipped ? 'Flip Axis' : 'Flip Axis' ) }}
         </b-switch>
       </b-col>
@@ -43,10 +43,7 @@
 <script lang="ts">
 import { Component, Vue, Prop, Watch } from "vue-property-decorator";
 import LocalDataHelper from "@/shared/LocalDataHelper";
-import Parsing from "@/shared/Parsing";
 import * as d3 from "d3";
-import swal from 'vue-sweetalert2'
-import { BIconArrowReturnRight } from "bootstrap-vue";
 import * as canvas from 'canvas'
 import DataHandler from "@/shared/DataHandler";
 @Component({
@@ -57,9 +54,7 @@ import DataHandler from "@/shared/DataHandler";
 })
 export default class Heatmap extends Vue {
 
-  private localDataHelper = new LocalDataHelper();
-  private parsing = new Parsing();
-  private isFlipped = true
+  public isFlipped = true
   $refs!: {
     heatmapDiv: HTMLElement;
     heatmapLegend: HTMLElement;
@@ -98,7 +93,7 @@ export default class Heatmap extends Vue {
       return  err
     } 
   }
-  downloadSVG(evt:any) {
+  downloadSVG() {
     var svg:any = document.querySelector("#innerheatmapSVG");
     var svg_xml = (new XMLSerializer()).serializeToString(svg),
     blob = new Blob([svg_xml], {type:'image/svg+xml;charset=utf-8'}),
@@ -198,15 +193,11 @@ export default class Heatmap extends Vue {
     }
     this.legendHeight = this.chartHeight / 20
     this.height = Math.min(this.chartHeight);    
-    const border = this.border;
-    const margin = this.margin;
     
     d3.selectAll("#heatmapSVG").remove()
     d3.select("#overflowDiv").remove()
     d3.selectAll("#heatmapSliderSVG").remove()
     d3.selectAll("#heatmapLegend").selectAll("*").remove()
-    const proteins = ["HA", "M1", "NA", "NP"];
-    const $this = this;
     this.makeHeatmap(this.DataHandler.cells)
 
   }
@@ -280,7 +271,6 @@ export default class Heatmap extends Vue {
     for (let i = -5; i <= 0; i+=0.25) {
       legendVals.push(i)
     }
-    const legend_margin: number= this.legendWidth - this.legendPadding
     const boxWidth = this.legendWidth / 4 / legendVals.length
     const legend_BoxHeight = this.legendHeight - this.legendPadding
     d3.select('#heatmapLegend')

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -116,7 +116,7 @@ export default class Heatmap extends Vue {
   margin = {
     top: 0.13 * this.chartHeight,
     bottom: 0.095 * this.chartHeight,
-    left: 0.02 * this.width,
+    left: 0.05 * this.width,
     right: 0.02 * this.width,
   };
   x: any = d3.scaleLinear()
@@ -399,8 +399,7 @@ export default class Heatmap extends Vue {
     let sliderBoxHeight = contextheight / preps.length
     let scaleY = d3.scaleOrdinal().domain(preps)
     .range(preps.map((d: any, i: number) => {
-        const spacing = boxHeight / 2;
-        return (i * boxHeight ) ;
+        return (i*sliderBoxHeight) ;
       })
     );    
     let subBars = this.context.selectAll(".subBar").data(this.DataHandler.cells)

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -219,7 +219,7 @@ export default class Heatmap extends Vue {
     // Set height of cells assuming that the height will be the default
     let boxHeight = (this.defaultChartHeight - this.margin.top - this.margin.bottom ) / this.preps.length 
     // this.boxHeight = boxHeight;
-    let maxBoxHeight = 50
+    let maxBoxHeight = 30
     this.boxHeight = Math.min(boxHeight, maxBoxHeight);
 
     // Reduce height of heatmap if cells will not fill its whole height
@@ -569,7 +569,6 @@ export default class Heatmap extends Vue {
     // Set distance between y axis labels
     this.scaleY.domain(scrollAttr.y).range(
       scrollAttr['y'].map((d: any, i: number) => {
-        const spacing = this.boxHeight / 2;
         return (i * this.boxHeight ) + this.margin.top;
       })
     );
@@ -661,7 +660,7 @@ export default class Heatmap extends Vue {
 
     // Set container of y axis to be width of svg
     const scaleYTextWidth = scaleYText.node().getBBox().width + this.labelPaddingLeft
-    d3.select("#labelsSVG").attr("viewBox", `0 0 ${scaleYTextWidth} ${this.chartHeight}`)
+    d3.select("#labelsSVG").attr("viewBox", `0 0 ${scaleYTextWidth} ${this.$refs.heatmapDiv.clientHeight}`)
     
     d3.select('#innerheatmapSVG')
     .attr("width", over)

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -25,7 +25,7 @@
         >
         </Heatmap>
       </div>
-       <b-col class="col-lg-4 pb-1 big-top-margin">
+       <b-col class="col-lg-4 pb-1">
         <MoleculeViewer 
           :pdb=pdb
           :position=position
@@ -82,7 +82,7 @@ export default class Visualization extends Vue {
   public referenceSequence: any[] = [];
   private localDataHelper = new LocalDataHelper();
   public switchedViewer = true
-  private DataHandler = new DataHandler()
+  public DataHandler = new DataHandler()
   $refs!: {
     heatmap: any;
     barplot: any;

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -24,6 +24,18 @@
           @changePosition="changePosition"
         >
         </Heatmap>
+        <div class="col-lg-12">
+          <hr class="solid">
+        </div>
+        <div class="pt-4">
+          <h3 class="title">Stacked Bar Chart</h3>
+          <h5 class="subtitle">Click a column in the heatmap to visualize its diversity</h5>
+          <BarPlot 
+            ref="barplot"
+            v-if="DataHandler.cells"
+            :DataHandler="DataHandler">
+          </BarPlot>
+        </div>
       </div>
        <b-col class="col-lg-4 pb-1">
         <MoleculeViewer 
@@ -34,18 +46,6 @@
           @changeReferenceSequence="changeReferenceSequence"
           >
         </MoleculeViewer>
-      </b-col>
-      <div class="col-lg-12">
-        <hr class="solid">
-      </div>
-      <b-col class="col-lg-8 pb-1">
-        <h3 class="title">Stacked Bar Chart</h3>
-        <h5 class="subtitle">Click a column in the heatmap to visualize its diversity</h5>
-        <BarPlot 
-          ref="barplot"
-          v-if="DataHandler.cells"
-          :DataHandler="DataHandler">
-        </BarPlot>
       </b-col>
       <canvas id="mycanvas"></canvas>
     </b-row>
@@ -116,7 +116,7 @@ export default class Visualization extends Vue {
     this.DataHandler.updateCells()
     this.sliderUpdate({target: "DataHandler", value: this.DataHandler})
   }  
-  
+
 }
 
 </script>


### PR DESCRIPTION
Changes:
* The heatmap component has been rearranged a little and thoroughly commented
* The y axis has been separated into its own svg so that when scrolling left and right, the y axis labels remain fixed
* The heatmap now collapses to a smaller height if there are fewer than 15 or so samples (number not confirmed)
* The shades of light gray which represent "no data" and "no mutations" are swapped so that the lighter gray represents "no data" and the darker gray represents "no mutations"
* The slider has a light gray background and no shadow
* The stacked bar chart has been moved up

There's more to do, but this seemed like enough for a PR. Let me know if you find any bugs!