### PR TITLE
View data from multiple organisms in heatmap

### DIFF
--- a/src/components/BarPlot.vue
+++ b/src/components/BarPlot.vue
@@ -108,14 +108,17 @@ export default class BindingSites extends Vue {
 
   makeBarPlot(){
 
+    // If no data, return
     if( this.DataHandler.cells.length < 1 ) {
       return
     }
 
+    // Remove old plots
     const $this = this
     d3.select("#barPlotDiv").selectAll("*").remove()
     d3.select('#barPlotLegend').selectAll("*").remove()
 
+    // Prepare data
     let preps: any = [...new Set(this.DataHandler.cells.map((d: any) => d.experiment))];
     // let aas: any = [...new Set(this.DataHandler.cells.map((d: any) => d.aa))];
     let data: any[] = d3.filter(this.DataHandler.cells, (d: any)=>{
@@ -134,13 +137,15 @@ export default class BindingSites extends Vue {
       return r
     })
     
-    let boxDim: any = (this.width - this.margin.right - this.margin.left) / preps.length
+    // Calculate dimensions of components
+    let boxDim: any = (this.$refs.barPlotDiv.clientWidth - this.margin.right - this.margin.left) / preps.length
     const minBoxWidth = 15
     boxDim = Math.max(boxDim, minBoxWidth)
     let chartWidth = boxDim * preps.length
     this.width = chartWidth + this.margin.right + this.margin.left
     this.chartHeight = this.containerHeight - this.margin.top - this.margin.bottom
     
+    // Create bar plot
     const barplotDiv = d3.select("#barPlotDiv")
     
     this.svg = barplotDiv.append("svg")
@@ -171,23 +176,9 @@ export default class BindingSites extends Vue {
       
     let svgG: any = innerSvg.append("g").attr("id", "svgG")
     
+    // Create x axis for samples
     let scaleX: any = d3.scaleBand().domain(preps)
-    .range([this.margin.left, chartWidth ])
-    
-    let scaleY: any = null
-    if (this.selected_scale == 'Linear'){
-      scaleY = d3.scaleLinear().domain([0, 1])
-      .range([this.chartHeight, this.margin.top ])
-    } else if (this.selected_scale == 'Sqrt' ){
-      scaleY = d3.scaleSqrt().domain([0,1])
-      .range([this.chartHeight, this.margin.top ])
-    }
-    else {
-      scaleY = d3.scaleSymlog().clamp(true).domain([0,1])
-      .range([this.chartHeight, this.margin.top ])
-    }
-      
-    let scaleColor: any = d3.scaleOrdinal().domain(this.colors).range(this.colors);
+    .range([this.margin.left, this.width ])
     
     let xAxisB: any = d3
       .axisBottom(scaleX)
@@ -205,6 +196,20 @@ export default class BindingSites extends Vue {
     .style('text-anchor', 'start')
     .attr('transform', 'rotate(45)').style("font-size", "1em")
 
+    // Create y axis with different scales
+    let scaleY: any = null
+    if (this.selected_scale == 'Linear'){
+      scaleY = d3.scaleLinear().domain([0, 1])
+      .range([this.chartHeight, this.margin.top ])
+    } else if (this.selected_scale == 'Sqrt' ){
+      scaleY = d3.scaleSqrt().domain([0,1])
+      .range([this.chartHeight, this.margin.top ])
+    }
+    else {
+      scaleY = d3.scaleSymlog().clamp(true).domain([0,1])
+      .range([this.chartHeight, this.margin.top ])
+    }
+    
     let yAxisB: any = d3
       .axisLeft(scaleY)
       .ticks(5)
@@ -219,7 +224,10 @@ export default class BindingSites extends Vue {
     .style("fill", null)
     .style("stroke-width", 0.2)
     .call(yAxisB)
+      
+    let scaleColor: any = d3.scaleOrdinal().domain(this.colors).range(this.colors);
 
+    // Create stacked bars
     let stacks: any = d3.stack().keys(this.aas)
     (data)
     .map((d:any)=>{
@@ -264,7 +272,8 @@ export default class BindingSites extends Vue {
     )
 
 
-    let legendHeight: number = $this.chartHeight   * 1
+    // Create legend
+    let legendHeight: number = $this.chartHeight * 1
     let legendWidth: number = this.width
     
     let legendMargin: any = {

--- a/src/components/BarPlot.vue
+++ b/src/components/BarPlot.vue
@@ -69,7 +69,7 @@ export default class BindingSites extends Vue {
   aas: string[]  = ["M", "K", "A", "I", "L", "V", "Y", "T", "F", "N", "D", "C", "G", "H", "S", "E", "P", "W", "R", "Q"]
 
 
-  downloadSVG(evt:any) {
+  downloadSVG() {
     var svg:any = document.querySelector("#innerheatmapSVGBarPlot");
     var svg_xml = (new XMLSerializer()).serializeToString(svg),
     blob = new Blob([svg_xml], {type:'image/svg+xml;charset=utf-8'}),
@@ -107,6 +107,11 @@ export default class BindingSites extends Vue {
   }
 
   makeBarPlot(){
+
+    if( this.DataHandler.cells.length < 1 ) {
+      return
+    }
+
     const $this = this
     d3.select("#barPlotDiv").selectAll("*").remove()
     d3.select('#barPlotLegend').selectAll("*").remove()
@@ -165,8 +170,6 @@ export default class BindingSites extends Vue {
 
       
     let svgG: any = innerSvg.append("g").attr("id", "svgG")
-    // let colors: string[] = ['#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231', '#911eb4', '#46f0f0', '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1', '#000075', '#808080', 'red', '#000']
-    // let aas: string[]  = ["M", "K", "A", "I", "L", "V", "Y", "T", "F", "N", "D", "C", "G", "H", "S", "E", "P", "W", "R", "Q"]
     
     let scaleX: any = d3.scaleBand().domain(preps)
     .range([this.margin.left, chartWidth ])

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -64,8 +64,8 @@ export default class Heatmap extends Vue {
   public column_width!: number;
   @Prop({ required: true, default: null })
   public DataHandler!: DataHandler;
-  @Prop({ required: false, default: true })
-  public sortBy!: any;
+  // @Prop({ required: false, default: true })
+  // public sortBy!: any;
   @Prop({ required: false, default: true })
   public amino_acid_label_option!: string;
   
@@ -123,10 +123,10 @@ export default class Heatmap extends Vue {
   yAxisLabels: any[] = []
     
   // Watchers that will update heatmap when user changes settings
-  @Watch("sortBy")
-  onSortByChanged(value: boolean, oldValue: boolean) {
-    this.updateHeatmap()
-  }
+  // @Watch("sortBy")
+  // onSortByChanged(value: boolean, oldValue: boolean) {
+  //   this.updateHeatmap()
+  // }
   @Watch("column_width")
   onColWidthChanged(value: number, oldValue: number) {
     this.updateHeatmap()

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -67,7 +67,7 @@ export default class Heatmap extends Vue {
   @Prop({ required: false, default: true })
   public sortBy!: any;
   @Prop({ required: false, default: true })
-  public amino_acid_label_option!: any;
+  public amino_acid_label_option!: string;
   
   customfile: any = null
   scrollDirection: string = "x"
@@ -131,7 +131,7 @@ export default class Heatmap extends Vue {
     this.updateHeatmap()
   }
   @Watch("amino_acid_label_option")
-  onAminoAcidLabelOptionChanged(value: number, oldValue: number) {
+  onAminoAcidLabelOptionChanged(value: string, oldValue: string) {
     this.updateHeatmap()
   }
 
@@ -221,6 +221,9 @@ export default class Heatmap extends Vue {
     this.boxHeight = Math.min(boxHeight, maxBoxHeight);
 
     this.$emit('update:column_width', this.boxHeight)
+    if (this.column_width <= 20) {
+      this.$emit('update:amino_acid_label_option', "None")
+    }
 
     // Reduce height of heatmap if cells will not fill its whole height
     if (this.boxHeight === maxBoxHeight) {

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -713,7 +713,6 @@ export default class Heatmap extends Vue {
                   }
                 })
                 .attr("fill", "currentColor")
-                // .attr("class", "block")
                 .attr("x", (d: any) => $this.scaleX(d.position) + $this.column_width / 3)
                 .attr("y", (d: any) => $this.scaleY(d.experiment) + $this.boxHeight / 1.5)
               return;

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -120,6 +120,7 @@ export default class Heatmap extends Vue {
   };
   x: any = d3.scaleLinear()
   labelPaddingLeft: number = 15; // Bootstrap columns add 15px of padding which must be accounted for in yAxis transforms
+  yAxisLabels: any;
     
   // Watchers that will update heatmap when user changes settings
   @Watch("sortBy")
@@ -216,6 +217,7 @@ export default class Heatmap extends Vue {
     // Get unique preps in order to calculate y axis
     let preps: any = [...new Set(cells.map((d: any) => d.experiment))];
     this.preps = preps
+    this.yAxisLabels = [...new Set(cells.map((d: any) => `${d.organism}\t\t${d.experiment}`))];
 
     // Set height of cells assuming that the height will be the default
     let boxHeight = (this.defaultChartHeight - this.margin.top - this.margin.bottom ) / this.preps.length 
@@ -507,7 +509,8 @@ export default class Heatmap extends Vue {
     if (this.scrollDirection == 'x'){
       scrollAttr['x'] = this.positions
       scrollAttr.xTicks = this.positions_unique;
-      scrollAttr['y'] = this.preps
+      scrollAttr['y'] = this.yAxisLabels
+      // scrollAttr['y'] = this.preps
       scrollAttr.marginA = this.margin.left
       scrollAttr.marginB = this.margin.right
       scrollAttr.long =  this.width     

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -672,6 +672,7 @@ export default class Heatmap extends Vue {
             g.on("click", (d:any, u:any)=>{
                 $this.DataHandler.selectedPosition = u.position
                 $this.$emit("changePosition", u.position)
+                $this.$emit("changePdb", u.pdb)
               })
               .on("mousemove", (event: any, u: any, n:any, i:number) => {
                 $this.highlightCell(event, u)

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -86,7 +86,7 @@ export default class Heatmap extends Vue {
   oversize: number = 0;
   border = 0;
   svgs = {};
-  scaleX = d3.scaleBand();
+  scaleX: any = d3.scaleBand();
   scaleColor = d3.scaleLinear();
   colors = { start: "#fff", end: "#666699" };
   xAxisInner = {};

--- a/src/components/Heatmap.vue
+++ b/src/components/Heatmap.vue
@@ -120,7 +120,7 @@ export default class Heatmap extends Vue {
   };
   x: any = d3.scaleLinear()
   labelPaddingLeft: number = 15; // Bootstrap columns add 15px of padding which must be accounted for in yAxis transforms
-  yAxisLabels: any;
+  yAxisLabels: any[] = []
     
   // Watchers that will update heatmap when user changes settings
   @Watch("sortBy")
@@ -217,7 +217,7 @@ export default class Heatmap extends Vue {
     // Get unique preps in order to calculate y axis
     let preps: any = [...new Set(cells.map((d: any) => d.experiment))];
     this.preps = preps
-    this.yAxisLabels = [...new Set(cells.map((d: any) => `${d.organism}\t\t${d.experiment}`))];
+    this.yAxisLabels = [...new Set(cells.map((d: any) => d.yAxisLabel))];
 
     // Set height of cells assuming that the height will be the default
     let boxHeight = (this.defaultChartHeight - this.margin.top - this.margin.bottom ) / this.preps.length 
@@ -510,7 +510,6 @@ export default class Heatmap extends Vue {
       scrollAttr['x'] = this.positions
       scrollAttr.xTicks = this.positions_unique;
       scrollAttr['y'] = this.yAxisLabels
-      // scrollAttr['y'] = this.preps
       scrollAttr.marginA = this.margin.left
       scrollAttr.marginB = this.margin.right
       scrollAttr.long =  this.width     
@@ -547,20 +546,20 @@ export default class Heatmap extends Vue {
       .range([scrollAttr.marginA, this.oversize - scrollAttr.marginB]);
 
     // Sort y axis labels by date if not flipped or name if flipped
-    if (! this.sortBy){
-      try {
-        scrollAttr.y = scrollAttr.y.sort((a: any, b:any) => {
-          let datea = a.split("-")
-          let dateb = b.split("-")
-          return datea[datea.length -1].localeCompare(dateb[dateb.length -1])
-        })
-      } catch(err){
-        console.log(err)
-        scrollAttr.y = scrollAttr.y.sort()
-      }
-    } else {
-      scrollAttr.y = scrollAttr.y.sort()
-    }
+    // if (! this.sortBy){
+    //   try {
+    //     scrollAttr.y = scrollAttr.y.sort((a: any, b:any) => {
+    //       let datea = a.split("-")
+    //       let dateb = b.split("-")
+    //       return datea[datea.length -1].localeCompare(dateb[dateb.length -1])
+    //     })
+    //   } catch(err){
+    //     console.log(err)
+    //     scrollAttr.y = scrollAttr.y.sort()
+    //   }
+    // } else {
+    //   scrollAttr.y = scrollAttr.y.sort()
+    // }
 
     // Set distance between y axis labels
     this.scaleY.domain(scrollAttr.y).range(

--- a/src/components/MoleculeViewer.vue
+++ b/src/components/MoleculeViewer.vue
@@ -169,10 +169,14 @@ export default class MoleculeViewer extends Vue {
   proteinChange(value: string){
     this.chain_focus = null
     const options: any= {
-      moleculeId: value,
       assemblyId: this.assemblyId,
       hideControls: true,
       bgColor: {r:255, g:255, b:255}
+    }
+    if(value === null) {
+      options.customData = { url: 'empty.pdb', format: 'mmcif'}
+    } else {
+      options.moleculeId = value
     }
     this.queryAPI(options)
     this.viewer.visual.update(options)

--- a/src/components/MoleculeViewer.vue
+++ b/src/components/MoleculeViewer.vue
@@ -2,7 +2,7 @@
   <b-row> 
     <b-col class="col-lg-12 pb-1">
       <div class="">
-        <b-field :label="this.title"></b-field>
+        <b-field :label="title"></b-field>
         <div >
           <b-input-group prepend="PDB ID" class="mt-3">
             <b-form-input type="text" v-model="pdb_local" ></b-form-input>
@@ -22,7 +22,7 @@
         </b-field>
         <b-field v-if="queryingReferenceSequence" label="Querying Reference Sequence..."></b-field>
         <b-field v-if="queryingResidueMapping" label="Querying Residue Mapping.."></b-field>
-        <b-field v-if="chain_focus" :label="'Chains at '+this.localPosition" class="column is-narrow">
+        <b-field v-if="chain_focus" :label="'Chains at '+localPosition" class="column is-narrow">
           <b-select placeholder="Chain" @change="focus()"  v-model="chain_focus" :options="available_focus_chains">
           </b-select>
         </b-field>
@@ -102,8 +102,8 @@ export default class MoleculeViewer extends Vue {
   
   @Prop({ required: true, default: 55 })
   public position!: string;
-  @Prop({ required: true, default: "5r7y" })
-  public pdb!: string;
+  @Prop({ required: true, default: null })
+  public pdb!: string|null;
 
   @Prop({ required: true, default: null })
   public DataHandler!: DataHandler
@@ -120,21 +120,17 @@ export default class MoleculeViewer extends Vue {
   CustomPDBFile(value: any, oldValue: any) {
     console.log(value)
   }
-  
   @Watch('referenceSequence', { immediate: true, deep: true })
   onRefSeqChange(value: any, oldValue: any) {
     if (value && Object.keys(value).length > 0){
       this.$emit("changeReferenceSequence", value)
     }
   }
-
-
   @Watch('DataHandler.pdb')
   onDataChanged(value: any, oldValue: any){
     this.pdb_local = value
     this.proteinChange(value)
   }
-
   @Watch('isSwitched')
   onSwitchToggled(value: any, oldValue: any) {
     if(value === true) {
@@ -143,6 +139,14 @@ export default class MoleculeViewer extends Vue {
       this.assemblyId = "preffered"
     }
     this.proteinChange(this.pdb)
+  }
+  @Watch('pdb')
+  onPdbChanged(value: any, oldValue:any) {
+    if (value === null || value === "") {
+      this.proteinChange(null)
+    } else {
+      this.proteinChange(value)
+    }
   }
 
 
@@ -166,7 +170,7 @@ export default class MoleculeViewer extends Vue {
     } 
   }
 
-  proteinChange(value: string){
+  proteinChange(value: string|null){
     this.chain_focus = null
     const options: any= {
       assemblyId: this.assemblyId,
@@ -281,7 +285,6 @@ export default class MoleculeViewer extends Vue {
                   
                 }
               }
-              this.referenceSequence = ref_seq
             }
           })
         }
@@ -334,9 +337,10 @@ export default class MoleculeViewer extends Vue {
     return localPosition - mapPosition
   }
 
-  // Example of focus ability. In the future let's rig this to the d3 heatmap so that when an amino acid is clicked, the molecule focuses on it
   focus() {
-    this.viewer.visual.clearSelection();
+    // try {
+    //   this.viewer.visual.clearSelection();
+    // } catch(e) {}
     let residue: Residue =  { chain: '', entity: '', position: 0 };
     let found: boolean = false
     for(let d of Object.keys(this.map_positions).sort().filter((e:any)=>{return e != 'total'})) {

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -23,6 +23,7 @@
           :DataHandler=DataHandler
           :amino_acid_label_option.sync=amino_acid_label_option
           @changePosition="changePosition"
+          @changePdb="changePdb"
         >
         </Heatmap>
         <div class="col-lg-12">
@@ -73,7 +74,7 @@ export default class Visualization extends Vue {
   public depth_threshold = 0
   public frequency_threshold = 0.2
   public column_width = 9
-  public pdb = null
+  public pdb:string|null = null
   public position = 54
   public cells:any = null
   public group: any[] = []
@@ -118,6 +119,9 @@ export default class Visualization extends Vue {
     this.DataHandler.updateCells()
     this.sliderUpdate({target: "DataHandler", value: this.DataHandler})
   }  
+  changePdb(value: string) {
+    this.pdb = value
+  }
 
 }
 

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -5,6 +5,7 @@
         <VisualizationOptions 
            @sliderUpdate="sliderUpdate"
            :column_width=column_width
+           :amino_acid_label_option=amino_acid_label_option
            />
          
       </b-col>
@@ -20,9 +21,8 @@
           ref="heatmap"
           :column_width.sync=column_width 
           :DataHandler=DataHandler
-          :isSwitched=isSwitched  
           :sortBy=sortBy      
-          
+          :amino_acid_label_option=amino_acid_label_option
           @changePosition="changePosition"
         >
         </Heatmap>
@@ -79,12 +79,13 @@ export default class Visualization extends Vue {
   public cells:any = null
   public group: any[] = []
   public customfile: any = null
-  public isSwitched: boolean = true
   public sortBy: boolean = true
   public referenceSequence: any[] = [];
   private localDataHelper = new LocalDataHelper();
   public switchedViewer = true
   public DataHandler = new DataHandler()
+  public amino_acid_label_option = "None"
+  
   $refs!: {
     heatmap: any;
     barplot: any;

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -22,7 +22,7 @@
           :column_width.sync=column_width 
           :DataHandler=DataHandler
           :sortBy=sortBy      
-          :amino_acid_label_option=amino_acid_label_option
+          :amino_acid_label_option.sync=amino_acid_label_option
           @changePosition="changePosition"
         >
         </Heatmap>

--- a/src/components/Visualization.vue
+++ b/src/components/Visualization.vue
@@ -21,7 +21,6 @@
           ref="heatmap"
           :column_width.sync=column_width 
           :DataHandler=DataHandler
-          :sortBy=sortBy      
           :amino_acid_label_option.sync=amino_acid_label_option
           @changePosition="changePosition"
         >
@@ -79,7 +78,7 @@ export default class Visualization extends Vue {
   public cells:any = null
   public group: any[] = []
   public customfile: any = null
-  public sortBy: boolean = true
+  // public sortBy: boolean = true
   public referenceSequence: any[] = [];
   private localDataHelper = new LocalDataHelper();
   public switchedViewer = true

--- a/src/components/VisualizationOptions.vue
+++ b/src/components/VisualizationOptions.vue
@@ -80,11 +80,11 @@
         <b-field label="Position Ranges" class="column is-2">
           <b-slider v-model="DataHandler.position_ranges" y :min="1" :max="DataHandler.position_max" @change="emitChange($event, { full: false, target: 'position_ranges' })" :step="1" ticks></b-slider>
         </b-field>
-        <b-field label="Sort" class="column is-narrow">
+        <!-- <b-field label="Sort" class="column is-narrow">
           <b-switch v-model="sortBy" >
             {{ ( sortBy ? 'Name' : 'Time' ) }}
           </b-switch>
-        </b-field>
+        </b-field> -->
         <b-field label="Amino Acid Labels" class="column is-narrow">
             <b-select :value="amino_acid_label_option" @input="onAminoAcidLabelChanged($event)">
               <option v-for="option in amino_acid_label_options" :value="option" :key="option">
@@ -130,7 +130,7 @@ export default class VisualizationOptions extends Vue {
   public customfile: any = null
   public showDiscordantOnly: boolean = true
   public isDataSwitched: boolean = true
-  public sortBy: boolean = true
+  // public sortBy: boolean = true
   minrange: number = 1
   maxrange: number = 1
   position_max: any =1
@@ -154,10 +154,10 @@ export default class VisualizationOptions extends Vue {
   onSwitchedChangeDataType(value: boolean, oldValue: boolean) {
     this.emitChange(value, { full: true, target: 'data_type_selected' })
   }
-  @Watch("sortBy")
-  onSortByChange(value: boolean, oldValue: boolean) {
-    this.$emit('sliderUpdate', {value: value, target: 'sortBy'})
-  }
+  // @Watch("sortBy")
+  // onSortByChange(value: boolean, oldValue: boolean) {
+  //   this.$emit('sliderUpdate', {value: value, target: 'sortBy'})
+  // }
 
   @Watch("customfile")
   async onChangeFile(value: any, oldValue: any) {

--- a/src/components/VisualizationOptions.vue
+++ b/src/components/VisualizationOptions.vue
@@ -16,10 +16,6 @@
       </b-col>
       <b-col sm="2">
           <b-field :label="(isDataSwitched ? 'Default Data' : 'Custom')" class="column is-narrow">
-            <!-- <b-switch :disabled="true" v-model="isDataSwitched" 
-            >
-              {{ ( isDataSwitched ? 'Sample' : 'Custom' ) }}
-            </b-switch> -->
             <b-select 
               placeholder="Data" 
               v-model="DataHandler.experiment"
@@ -92,10 +88,12 @@
             {{ ( sortBy ? 'Name' : 'Time' ) }}
           </b-switch>
         </b-field>
-        <b-field label="Axis labels" class="column is-narrow">
-          <b-switch v-model="isSwitched" >
-            {{ ( !isSwitched ? 'Consensus' : 'PDB Reference' ) }}
-          </b-switch>
+        <b-field label="Amino Acid Labels" class="column is-narrow">
+            <b-select :value="amino_acid_label_option" @input="onAminoAcidLabelChanged($event)">
+              <option v-for="option in amino_acid_label_options" :value="option" :key="option">
+                {{ option }}
+              </option>
+            </b-select>
         </b-field>
       </div>
     </b-tab>
@@ -138,7 +136,6 @@ export default class VisualizationOptions extends Vue {
   public proteins: Array<string> = []
   public group: any[] = []
   public groups: Array<any> = []
-  public isSwitched: boolean = true
   public isDataSwitched: boolean = true
   public sortBy: boolean = true
   minrange: number = 1
@@ -151,15 +148,15 @@ export default class VisualizationOptions extends Vue {
   public referenceSequence!: any;
   @Prop({ required: false})
   public column_width!: number;
+  @Prop({ required: false})
+  public amino_acid_label_option!: string;
 
   public DataHandler = new DataHandler()
 
+  amino_acid_label_options = ["None", "Consensus amino acids", "Reference amino acids"]
+
   activeTab = 0
 
-  @Watch("isSwitched")
-  onSwitchedChange(value: boolean, oldValue: boolean) {
-    this.$emit('sliderUpdate', {value: value, target: 'isSwitched'})
-  }
   @Watch("isDataSwitched")
   onSwitchedChangeDataType(value: boolean, oldValue: boolean) {
     this.emitChange(value, { full: true, target: 'data_type_selected' })
@@ -194,6 +191,10 @@ export default class VisualizationOptions extends Vue {
 
   onColWidthChanged(value: number) {
     this.$emit('sliderUpdate', {value: value, target: 'column_width'})
+  }
+
+  onAminoAcidLabelChanged(value: string) {
+    this.$emit('sliderUpdate', {value: value, target: 'amino_acid_label_option'})
   }
 
   @Watch('depth_threshold')

--- a/src/components/VisualizationOptions.vue
+++ b/src/components/VisualizationOptions.vue
@@ -54,15 +54,12 @@
         <b-col sm="2">
           <b-field label="Organism" class="column is-narrow">
             <b-select 
-            placeholder="Organism"   :disabled="DataHandler.changing"
-            v-model="DataHandler.organism" 
+            placeholder="Organism" :disabled="DataHandler.changing"
+            v-if="DataHandler.organism" 
+            v-model="DataHandler.organism"
+            multiple
+            :options="DataHandler.organisms"
             @change="emitChange($event, { full: true, target: 'organism' })">
-              <option
-              v-for="option in DataHandler.organisms"
-              :value="option"
-              :key="option">
-                {{ option }}
-              </option>
             </b-select>
           </b-field>
         </b-col>
@@ -131,11 +128,7 @@ export default class VisualizationOptions extends Vue {
   public data:any = null
   public cells: any = null
   public customfile: any = null
-  public protein: string = ""
   public showDiscordantOnly: boolean = true
-  public proteins: Array<string> = []
-  public group: any[] = []
-  public groups: Array<any> = []
   public isDataSwitched: boolean = true
   public sortBy: boolean = true
   minrange: number = 1

--- a/src/shared/DataHandler.ts
+++ b/src/shared/DataHandler.ts
@@ -41,8 +41,8 @@ export default class DataHandler {
     pdb_map: any  = {}
     selected_consensus: any = null
     public changing: boolean = false
-    public defaultDataListFile: any = path.join("data", "SecondExampleInputVariantsIVAR.json")
-    public defaultDataListFiles: any[] = [path.join("data", "SecondExampleInputVariantsIVAR.json"), path.join("data", "default.json"), path.join("data", "Gaydos.json")];
+    public defaultDataListFile: any = path.join("data", "ivar2 (1).json")
+    public defaultDataListFiles: any[] = [path.join("data", "SecondExampleInputVariantsIVAR.json"), path.join("data", "default.json"), path.join("data", "Gaydos.json"), path.join("data", "ivar2 (1).json")];
     data_selected: any  = null
     public  constructor() {
         this.data_selected = this.defaultDataListFile
@@ -63,8 +63,6 @@ export default class DataHandler {
     public updateProtein(protein: any)
     {
         this.protein = protein
-        // this.pdb = this.pdb_map[this.organism[0]][protein]
-        this.updateData()
     }
     public changeExperiment(experiment: any )
     {
@@ -117,6 +115,7 @@ export default class DataHandler {
         const $this = this
         this.changing = true
         let genes = this.filter()
+        if (genes.length === 0) return
         let cells: any = []
         let seen_positions:any  = {}
         genes.forEach((gene:any)=>{
@@ -205,9 +204,6 @@ export default class DataHandler {
         const max: any = d3.max(cells.map((d:any)=>{return +d.position}))
         this.position_max = max
         this.position_min = min
-        // console.log(Object.keys(this.pdb_map))
-        // console.log(this.organism[0])
-        // console.log(this.pdb_map[this.organism[0]])
         this.position_ranges = [1, this.protein_map[this.organism[0]][this.protein].length]
         if (this.organism[0] in this.pdb_map && this.protein in this.pdb_map[this.organism[0]]) {
             this.pdb = this.pdb_map[this.organism[0]][this.protein]
@@ -278,14 +274,12 @@ export default class DataHandler {
             // })
         )
         $this.organisms = [ ... new Set(data_filtered.map((d:any)=>{return d.organism}))]
-        if (!$this.organism || $this.organisms.indexOf($this.organism) == -1 ) { $this.organism = $this.organisms } 
+        if (!$this.organism || $this.organism.length === 0) { $this.organism = $this.organisms } 
         $this.samples = [ ...new Set(data_filtered.map((d: any) => {return d.sample}))];
         $this.groups = [...new Set(data_filtered.map((d: any) => {return  d.group}))];
        
-        if (!this.sample || this.sample.length == 0) { this.sample = this.samples }
-        // if (!this.organism  ) { this.organism = this.organisms[0] }
-        if (!this.organism || this.organisms.length == 0 ) { 
-            this.organism = this.organisms
+        if (!this.sample || this.sample.length === 0) { this.sample = this.samples }
+        if (!$this.organism || $this.organisms.length === 0 ) { 
             if (! ($this.protein in $this.protein_map[$this.organism[0]])){
                 $this.organisms.forEach((organism)=>{
                     if ($this.protein in $this.protein_map[organism]){

--- a/src/shared/DataHandler.ts
+++ b/src/shared/DataHandler.ts
@@ -41,8 +41,8 @@ export default class DataHandler {
     pdb_map: any  = {}
     selected_consensus: any = null
     public changing: boolean = false
-    public defaultDataListFile: any = path.join("data", "ivar2 (1).json")
-    public defaultDataListFiles: any[] = [path.join("data", "SecondExampleInputVariantsIVAR.json"), path.join("data", "default.json"), path.join("data", "Gaydos.json"), path.join("data", "ivar2 (1).json")];
+    public defaultDataListFile: any = path.join("data", "SecondExampleInputVariantsIVAR.json")
+    public defaultDataListFiles: any[] = [path.join("data", "SecondExampleInputVariantsIVAR.json"), path.join("data", "default.json"), path.join("data", "BARDA_New.json"), path.join("data", "Gaydos.json")];
     data_selected: any  = null
     public  constructor() {
         this.data_selected = this.defaultDataListFile

--- a/src/shared/DataHandler.ts
+++ b/src/shared/DataHandler.ts
@@ -292,7 +292,6 @@ export default class DataHandler {
         data_filtered.sort( (a:any, b:any) => {
             return (a.yAxisLabel > b.yAxisLabel) ? 1 : ((b.yAxisLabel > a.yAxisLabel) ? -1 : 0)
         })
-        console.log(data_filtered)
             
 
         return data_filtered

--- a/src/shared/DataHandler.ts
+++ b/src/shared/DataHandler.ts
@@ -163,7 +163,9 @@ export default class DataHandler {
                     aa: residue.reference_aa,
                     aa_count: aa_count,
                     consensus_aa: residue.consensus_aa, 
-                    consensus_count: residue.consensus_aa_count 
+                    consensus_count: residue.consensus_aa_count,
+                    pdb: gene.pdb,
+                    yAxisLabel: gene.yAxisLabel
                 })
             })
             let positions = depths.map((d:any, i:any)=>{
@@ -193,7 +195,9 @@ export default class DataHandler {
                             aa: aa,
                             aa_count: depth,
                             consensus_aa: aa, 
-                            consensus_count: depth
+                            consensus_count: depth,
+                            pdb: this.pdb_map[organism][gene.gene],
+                            yAxisLabel: gene.yAxisLabel,
                         })
                     }
                 } 
@@ -210,9 +214,11 @@ export default class DataHandler {
         } else {
             this.pdb = null
         }
+        
+
         this.cells_full = cells
         this.changing = false
-        
+
     }
     private parseGroups(group: any, groups: any){
         let grp
@@ -255,6 +261,7 @@ export default class DataHandler {
                 item.experiment = d.experiment;
                 item.group = d.group;
                 item.sample = d.sample 
+                item.yAxisLabel = `${item.organism}\t${d.sample}`
                 return item
             })
         }))
@@ -262,17 +269,7 @@ export default class DataHandler {
         if (!$this.protein || $this.proteins.indexOf($this.protein) == -1){ $this.protein = $this.proteins[0] }
         data_filtered  = [].concat.apply([], data_filtered.filter((d:any)=>{
             return d.gene== $this.protein
-        })
-            // .map((d:any)=>{
-            //     return d.genes.map((gene:any)=>{
-            //         gene.experiment = d.experiment;
-            //         gene.group = d.group;
-            //         gene.sample = d.sample;
-            //         gene.organism = d.organism
-            //         return gene
-            //     })
-            // })
-        )
+        }))
         $this.organisms = [ ... new Set(data_filtered.map((d:any)=>{return d.organism}))]
         if (!$this.organism || $this.organism.length === 0) { $this.organism = $this.organisms } 
         $this.samples = [ ...new Set(data_filtered.map((d: any) => {return d.sample}))];
@@ -292,6 +289,10 @@ export default class DataHandler {
         data_filtered = data_filtered.filter((d:any)=>{
             return $this.group.indexOf(d.group) > - 1  && $this.organism.includes(d.organism) && $this.sample.indexOf(d.sample) > -1
         })
+        data_filtered.sort( (a:any, b:any) => {
+            return (a.yAxisLabel > b.yAxisLabel) ? 1 : ((b.yAxisLabel > a.yAxisLabel) ? -1 : 0)
+        })
+        console.log(data_filtered)
             
 
         return data_filtered


### PR DESCRIPTION
Closes #17 

* Remove amino acids from heatmap x axes. Add amino acids to heatmap squares. Add dropdown to heatmap settings which controls whether consensus or reference amino acids are shown. Automatically remove amino acid labels when block width is < 20 units.
* Update data handler to support selected organism as an array instead of string. Convert organism chooser to be a multi select box. Show the organism that a sample was aligned to in the y axis label.
* Automatically load the pdb for the first organism in the molecule viewer. When a square is clicked, load the pdb for that square before focusing on the position
* Clean up and comment bar plot d3 code
* Remove sort and axis labels switches from heatmap
* Various bug fixes